### PR TITLE
Fix: no pull from gitops ArgoCD due to path issue #17

### DIFF
--- a/Apps/Client/argocd/app-dev.yaml
+++ b/Apps/Client/argocd/app-dev.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: 'https://github.com/nayem9b/bookifyCD.git'
     targetRevision: HEAD
-    path: k8s/overlays/dev
+    path: Apps/Client/k8s/overlays/dev
   destination:
     server: https://kubernetes.default.svc
     namespace: dev


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to reference the correct directory path for Kubernetes configuration overlays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->